### PR TITLE
Fix sending messages

### DIFF
--- a/lib/apns/connection/worker.ex
+++ b/lib/apns/connection/worker.ex
@@ -225,7 +225,7 @@ defmodule APNS.Connection.Worker do
       payload                   ::  binary,
       3                         ::  8,
       4                         ::  16-big,
-      msg.id                    ::  binary,
+      msg.id                    ::  4-big-unsigned-integer-unit(8),
       4                         ::  8,
       4                         ::  16-big,
       msg.expiry                ::  4-big-unsigned-integer-unit(8),


### PR DESCRIPTION
I have no idea why, but I was unable to get it to work by sending the `id` as a binary. It might be worth testing this out on your end before merging this in.
