### PR TITLE
Can set cert path relative to priv directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ config :apns,
 
 Name               | Default value  | Description
 :----------------- | :------------- | :-------------------
-certfile           | nil            | Path to APNS certificate file
+certfile           | nil            | Path to APNS certificate file or a tuple like `{:my_app, "certs/cert.pem"}` which will use a path relative to the `priv` folder of the given application.
 cert_password      | nil            | APNS certificate password (if any)
 keyfile            | nil            | Path to APNS keyfile
 callback_module    | APNS.Callback  | This module will receive all error and feedback messages from APNS

--- a/lib/apns/worker.ex
+++ b/lib/apns/worker.ex
@@ -12,7 +12,7 @@ defmodule APNS.Worker do
   def init(name) do
     config = get_config(name)
     ssl_opts = [
-      certfile: Path.absname(config.certfile),
+      certfile: certfile_path(config.certfile),
       reuse_sessions: false,
       mode: :binary
     ]
@@ -244,6 +244,14 @@ defmodule APNS.Worker do
 
   defp ssl_close(nil), do: nil
   defp ssl_close(socket), do: :ssl.close(socket)
+
+  defp certfile_path(string) when is_binary(string) do
+    Path.expand(string)
+  end
+
+  defp certfile_path({app_name, path}) when is_atom(app_name) do
+    Path.expand(path, :code.priv_dir(app_name))
+  end
 
   defp get_config(name) do
     opts = [


### PR DESCRIPTION
This allows the path to the certificate to be set to a location relative to the `priv` directory of the given application. This is useful since `priv` will be packaged along with the code when using `exrm`. This allows the certificates to be included in the application bundle.

This needs to be handled at runtime because the priv directory does not yet exist when evaluating the configuration.
