### PR TITLE
Allow dynamic connections to APNS

### DIFF
--- a/lib/apns/worker.ex
+++ b/lib/apns/worker.ex
@@ -12,10 +12,21 @@ defmodule APNS.Worker do
   def init(pool_conf) do
     config = get_config(pool_conf)
     ssl_opts = [
-      certfile: certfile_path(config.certfile),
       reuse_sessions: false,
       mode: :binary
     ]
+    if config.certfile != nil do
+      ssl_opts = ssl_opts
+      |> Dict.put(:certfile, certfile_path(config.certfile))
+    end
+    if config.cert != nil do
+      ssl_opts = ssl_opts
+      |> Dict.put(:cert, config.cert)
+    end
+    if config.key != nil do
+      ssl_opts = ssl_opts
+      |> Dict.put(:key, config.key)
+    end
     if config.keyfile != nil do
       ssl_opts = ssl_opts
       |> Dict.put(:keyfile, Path.absname(config.keyfile))
@@ -270,6 +281,8 @@ defmodule APNS.Worker do
 
   defp get_config(pool_conf) do
     opts = [
+      cert: nil,
+      key: nil,
       certfile: nil,
       cert_password: nil,
       keyfile: nil,


### PR DESCRIPTION
rationale :

APNs configurations are not available when starting the elixir project, but are instead saved in a database (e.g. MySQL). We want to be able to dynamically create a connections when the configurations become available. Furthermore we can add a new application configuration on the fly.

solution :
- add a new interface APNS.connect_pool(name, configuration)
- allow the pool configuration to use a certificate that is not stored in a file, using the :cert and :key properties of ssl_options instead of :certfile
