### PR TITLE
Pause the worker for 'timeout' in case the host is unreachable

### DIFF
--- a/lib/apns/worker.ex
+++ b/lib/apns/worker.ex
@@ -62,6 +62,7 @@ defmodule APNS.Worker do
         {:noreply, %{state | socket_apple: socket, counter: 0}}
       {:error, reason} ->
         Logger.error "[APNS] failed to connect #{address}, reason given: #{inspect reason}"
+        :timer.sleep(timeout)
         {:stop, {:connection_failed, address}, state}
     end
   end
@@ -79,6 +80,7 @@ defmodule APNS.Worker do
         {:noreply, %{state | socket_feedback: socket}}
       {:error, reason} ->
         Logger.error "[APNS] failed to connect #{address}, reason given: #{inspect reason}"
+        :timer.sleep(timeout)
         {:stop, {:connection_failed, address}, state}
     end
   end


### PR DESCRIPTION
**Issue**: if any of the `*.push.apple.com` hosts are unreachable the app dependent on `apns` won't start properly since APNS will infinitely try to reconnect. 

**Solution**: this PR adds a delay after the connection error was detected. The delay interval is equal to `config.timeout` used right now in `:ssl.connect` call. The operation will block one of the Poolboy processes too, preventing an avalanche of new connect requests too.

**Disclaimer**: There might be a better way to do it in Supervisor, but this works too.
