### PR TITLE
Log SSL responses

### DIFF
--- a/lib/apns/worker.ex
+++ b/lib/apns/worker.ex
@@ -265,7 +265,14 @@ defmodule APNS.Worker do
       byte_size(frame)  ::  32,
       frame             ::  binary
     >>
-    :ssl.send(socket, [packet])
+
+    result = :ssl.send(socket, [packet])
+    case result do
+      :ok -> Logger.debug("[APNS] success sent to #{msg.token}")
+      {:error, reason} -> Logger.error("[APNS] error (#{reason}) sending to #{msg.token}")
+    end
+
+    result
   end
 
   defp ssl_close(nil), do: nil


### PR DESCRIPTION
This allows the user of the lib to verify sending of pushes. If log level is `:info` or higher `Logger` defaults to removing these calls altogether, thous casing no overhead.

Also log errors if `:ssl.send/2` responds with an error.
