### PR TITLE
Send message id as integer to error callback module

### DIFF
--- a/lib/apns/worker.ex
+++ b/lib/apns/worker.ex
@@ -104,7 +104,7 @@ defmodule APNS.Worker do
 
   def handle_info({:ssl, socket, data}, %{socket_apple: socket} = state) do
     case <<state.buffer_apple :: binary, data :: binary>> do
-      <<8 :: 8, status :: 8, msg_id :: binary-4, rest :: binary>> ->
+      <<8 :: 8, status :: 8, msg_id :: integer-32, rest :: binary>> ->
         APNS.Error.new(msg_id, status)
         |> state.config.callback_module.error()
         case rest do


### PR DESCRIPTION
When the worker calls the error module for invalid token size the message id is an integer
"[APNS] Error %APNS.Error{error: "Invalid token size", message_id: 125785236, status: 5} for message 125785236"

… but when it is called because the token is invalid the message_id is a bitstring.
"[APNS] Feedback received for token %APNS.Error{error: "Invalid token", message_id: <<7, 127, 84, 148>>, status: 8}"

This is confusing to us. This PR makes the error always receive an integer.
