### PR TITLE
Log the message id so that it can be associated with callback logs

### DIFF
--- a/lib/apns/worker.ex
+++ b/lib/apns/worker.ex
@@ -274,8 +274,8 @@ defmodule APNS.Worker do
 
     result = :ssl.send(socket, [packet])
     case result do
-      :ok -> Logger.debug("[APNS] success sent to #{msg.token}")
-      {:error, reason} -> Logger.error("[APNS] error (#{reason}) sending to #{msg.token}")
+      :ok -> Logger.debug("[APNS] success sent #{msg.id} to #{msg.token}")
+      {:error, reason} -> Logger.error("[APNS] error (#{reason}) sending #{msg.id} to #{msg.token}")
     end
 
     result


### PR DESCRIPTION
We realize that we often want to see which APNS token did received errors in `Callback.error/1`. We figured that the simplest way to do this is to log the message id and apns token for each push sent. We can then associate the message id logged in `Callback.error/1` with the log from the worker and in that way find the token.
