### PR TITLE
Do not resend old messages

### DIFF
--- a/lib/apns/message_worker.ex
+++ b/lib/apns/message_worker.ex
@@ -28,7 +28,7 @@ defmodule APNS.MessageWorker do
     case sender.connect_socket(host, port, opts, config.timeout) do
       {:ok, socket} ->
         APNS.Logger.debug("successfully connected to socket")
-        {:ok, %{state | socket_apple: socket, counter: 0}}
+        {:ok, %{state | socket_apple: socket, counter: 0, queue: []}}
       {:error, _} ->
         APNS.Logger.warn("unable to connect to socket, backing off")
         {:backoff, 1000, state}
@@ -164,6 +164,10 @@ defmodule APNS.MessageWorker do
   end
 
   defp messages_after(queue, failed_id) do
-    Enum.take_while(queue, fn(message) -> message.id != failed_id end)
+    if Enum.find(queue, fn(message) -> message.id == failed_id end) do
+      Enum.take_while(queue, fn(message) -> message.id != failed_id end)
+    else
+      []
+    end
   end
 end


### PR DESCRIPTION
I've had some issues with old messages being resent recently.

The issue seems to be two 
#### Old queues are never cleared

We should reset the queue each time we connect to a socket.
#### Apple sending weird errors are not handled correctly.

We get errors sometimes by Apple complaining about messages with id 0. I don't know why, but this is an issue because when we try to find what messages to resend, we take all messages before the failed one: 
https://github.com/chvanikoff/apns4ex/blob/master/lib/apns/message_worker.ex#L167

The problem is that if the message is NOT in the queue (i.e. the weird id 0 message), we resend all messages in the queue. These may be old ones as we never clear the queues...

This PR should fix both these issues.
