### PR TITLE
Relax poison dependency.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule APNS.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 2.1"},
+      {:poison, "~> 1.5 or ~> 2.1"},
       {:poolboy, "~> 1.5"},
       {:connection, "~> 1.0.2"}
     ]


### PR DESCRIPTION
`decode!` and `encode!` work the same in 1.x and 2.x, so I relaxed the dependency.
