### PR TITLE
Add synchronous call

### DIFF
--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -26,4 +26,11 @@ defmodule APNSTest do
     output = capture_log(fn -> assert :ok = APNS.push(:test, message) end)
     assert_log output, "23:1becf2 sending message"
   end
+
+  @tag :real
+  test "push_sync/2 pushes message to worker synchronously", %{message: message} do
+    output = capture_log(fn -> assert :ok = APNS.push_sync(:test, message) end)
+    assert_log output, "23:1becf2 sending message"
+    assert {:error, _} = APNS.push_sync(:test, Map.put(message, :token, "badtoken"))
+  end
 end


### PR DESCRIPTION
Currently, there was only an async version of `push`.
I would like to use a synchronous version, as I am already making it async somewhere else,
and recording notifications that processed correctly.
This does not touch any existing API, simply adding a sync version of `push`.

Thank you.
