### PR TITLE
Avoid failing when no pools are present

### DIFF
--- a/lib/apns.ex
+++ b/lib/apns.ex
@@ -31,7 +31,7 @@ defmodule APNS do
     opts = [strategy: :one_for_one, name: APNS.Supervisor]
     supervisor = Supervisor.start_link([], opts)
 
-    pools = Application.get_env(:apns, :pools)
+    pools = Application.get_env(:apns, :pools, [])
     pools |> Enum.map(fn({name, conf}) -> connect_pool(name, conf) end)
 
     supervisor


### PR DESCRIPTION
Hi, would it be possible to default the pools to `[]`.
While I understand it is often desirable to configure them using
`mix config`, I configure them at runtime in [my library](https://github.com/tuvistavie/pushex/issues/4) and `apns4ex` 
therefore fails on boot: https://github.com/tuvistavie/pushex/issues/4 

Thanks!