### PR TITLE
Add support for `mutable-content` flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ defstruct [
   alert: "",
   badge: nil,
   sound: "default",
+  mutable_content: nil,
   priority: 10,
   extra: [],
   support_old_ios: nil

--- a/lib/apns/message.ex
+++ b/lib/apns/message.ex
@@ -9,6 +9,7 @@ defmodule APNS.Message do
     alert: "",
     badge: nil,
     sound: "default",
+    mutable_content: nil,
     priority: 10,
     extra: [],
     support_old_ios: nil,

--- a/lib/apns/payload.ex
+++ b/lib/apns/payload.ex
@@ -1,6 +1,6 @@
 defmodule APNS.Payload do
   defmodule Aps do
-    defstruct [:sound, :category, :badge, :content_available, :alert]
+    defstruct [:sound, :category, :badge, :content_available, :alert, :mutable_content]
   end
 
   import APNS.Utils.Map, only: [compact: 1, rename_key: 3]
@@ -33,6 +33,7 @@ defmodule APNS.Payload do
       struct(%APNS.Payload.Aps{}, Map.from_struct(message))
       |> Map.from_struct()
       |> rename_key(:content_available, :'content-available')
+      |> rename_key(:mutable_content, :'mutable-content')
       |> compact()
 
     Map.put(payload, :aps, merged)

--- a/test/lib/apns/payload_test.exs
+++ b/test/lib/apns/payload_test.exs
@@ -80,6 +80,11 @@ defmodule APNS.PayloadTest do
     assert json_payload(message)["aps"]["content-available"] == "my content_available"
   end
 
+  test "build_json adds mutable_content if present", %{message: message} do
+    message = Map.put(message, :mutable_content, 1)
+    assert json_payload(message)["aps"]["mutable-content"] == 1
+  end
+
   test "build_json adds extra if present", %{message: message} do
     message = Map.put(message, :extra, %{customkey: "my extra"})
     assert json_payload(message)["customkey"] == "my extra"


### PR DESCRIPTION
Used when modifying the contents of a push notification inside a [UNNotificationServiceExtension](https://developer.apple.com/reference/usernotifications/unnotificationserviceextension) on iOS 10.