### PR TITLE
0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.9.6 (2017-03-14)
+A bigger than usual update
+- merged PR#49, PR#53, PR#54
+- Added a backoff timeout, it will use `timeout` from config instead just 1 seconds
+- Minor clean up and test fixes
+- Better logging when connection fails
+- Elixir 1.4 compatibility (removed warnings)
+- Library/dependency updates
+
 ## 0.9.3 (2016-07-19)
 * A fix for certificate keys parsing (thanks @tuvistavie)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The older version of the library is available in `0.0.x-stable` branch
   1. Add apns to your list of dependencies in mix.exs:
 
         def deps do
-          [{:apns, "~> 0.9.1"}]
+          [{:apns, "~> 0.9.6"}]
         end
 
   2. Ensure apns is started before your application:

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :apns,
   pools: [
     test: [
       env: :dev,
-      certfile: {:apns, Path.expand("../priv/certs/dev.pem", __DIR__)},
+      certfile: {:apns, Path.expand("../priv/certs/dev.crt", __DIR__)},
       pool_size: 10,
       pool_max_overflow: 0 # WARNING: more than zero overflow seems bad!
     ]

--- a/lib/apns/feedback_worker.ex
+++ b/lib/apns/feedback_worker.ex
@@ -29,8 +29,8 @@ defmodule APNS.FeedbackWorker do
         APNS.Logger.info("successfully opened connection to feedback service")
         {:ok, %{state | socket_feedback: socket}}
       {:error, reason} ->
-        APNS.Logger.warn("error (#{inspect(reason)}) opening connection to feedback service")
-        {:backoff, 1000, state}
+        APNS.Logger.warn("error (#{inspect(reason)}) opening connection to feedback service, backing off for #{config.timeout} seconds")
+        {:backoff, config.timeout * 1000, state}
     end
   end
 

--- a/lib/apns/message_worker.ex
+++ b/lib/apns/message_worker.ex
@@ -35,8 +35,8 @@ defmodule APNS.MessageWorker do
         APNS.Logger.debug("successfully connected to socket")
         {:ok, %{state | socket_apple: socket, counter: 0, queue: []}}
       {:error, _} ->
-        APNS.Logger.warn("unable to connect to socket, backing off")
-        {:backoff, 1000, state}
+        APNS.Logger.warn("unable to connect to socket, backing off for #{config.timeout} seconds")
+        {:backoff, config.timeout * 1000, state}
     end
   end
 

--- a/lib/apns/ssl_configuration.ex
+++ b/lib/apns/ssl_configuration.ex
@@ -46,10 +46,14 @@ defmodule APNS.SslConfiguration do
 
   defp key(%{key: nil} = config), do: config
   defp key(%{key: binary_key} = config) do
-    [{:RSAPrivateKey, key_der, _}] = :public_key.pem_decode(binary_key)
-    Map.put(config, :key, {:RSAPrivateKey, key_der})
+    [{:PrivateKeyInfo, key_der, _}] = :public_key.pem_decode(binary_key)
+    Map.put(config, :key, {:PrivateKeyInfo, key_der})
   end
 
   defp keyfile(%{keyfile: nil} = config), do: config
-  defp keyfile(%{keyfile: binary_keyfile} = config), do: Map.put(config, :keyfile, Path.absname(binary_keyfile))
+  defp keyfile(%{keyfile: binary_keyfile} = config) when is_binary(binary_keyfile), do: Map.put(config, :keyfile, Path.absname(binary_keyfile))
+  defp keyfile(%{keyfile: {app_name, path}} = config) when is_atom(app_name) do
+    path = Path.expand(path, :code.priv_dir(app_name))
+    Map.put(config, :keyfile, path)
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,12 +4,12 @@ defmodule APNS.Mixfile do
   def project do
     [
       app: :apns,
-      version: "0.9.4",
+      version: "0.9.6",
       elixir: "~> 1.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
-      package: package,
+      deps: deps(),
+      package: package(),
       name: "apns4ex",
       source_url: "https://github.com/chvanikoff/apns4ex",
       description: """
@@ -32,7 +32,7 @@ defmodule APNS.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 1.5 or ~> 2.1"},
+      {:poison, "~> 1.5 or ~> 2.1 or ~>3.0"},
       {:poolboy, "~> 1.5"},
       {:connection, "~> 1.0.2"},
       {:ex_doc, ">= 0.0.0", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
-%{"connection": {:hex, :connection, "1.0.2", "f4a06dd3ecae4141aa66f94ce92ea4c4b8753069472814932f1cadbc3078ab80", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
+%{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/test/lib/apns/feedback_worker_test.exs
+++ b/test/lib/apns/feedback_worker_test.exs
@@ -54,7 +54,7 @@ defmodule APNS.FeedbackWorkerTest do
   end
 
   test "connect returns :backoff when connection is unsuccessful", %{state: state} do
-    assert {:backoff, 1000, state} == FeedbackWorker.connect(:anything, state, APNS.FakeSenderConnectFail)
+    assert {:backoff, 9000, state} == FeedbackWorker.connect(:anything, state, APNS.FakeSenderConnectFail)
   end
 
   test "disconnect reconnects and removes socket from state", %{state: state} do
@@ -108,7 +108,7 @@ defmodule APNS.FeedbackWorkerTest do
   defp start_worker do
     {:ok, worker} = FeedbackWorker.start_link([
       env: :dev,
-      certfile: {:apns, "certs/dev.pem"},
+      certfile: {:apns, "certs/dev.crt"},
       pool: :test,
       cert_password: '4epVi6VwfjvlrBZYLsoy4fAC4noef5Y'
     ])

--- a/test/lib/apns/message_worker_test.exs
+++ b/test/lib/apns/message_worker_test.exs
@@ -76,7 +76,7 @@ defmodule APNS.MessageWorkerTest do
 
   test "connect returns error if connection failed", %{state: state} do
     result = MessageWorker.connect(:anything, state, APNS.FakeSenderConnectFail)
-    assert result == {:backoff, 1000, state}
+    assert result == {:backoff, 10000, state}
   end
 
   test "handle_cast :send calls error callback if token is invalid size", %{state: state, message: message} do

--- a/test/lib/apns/package_test.exs
+++ b/test/lib/apns/package_test.exs
@@ -1,8 +1,6 @@
 defmodule APNS.PackageTest do
   use ExUnit.Case
 
-  @payload_min_size 38
-
   setup do
     message =
       APNS.Message.new(123)

--- a/test/lib/apns/ssl_configuration_test.exs
+++ b/test/lib/apns/ssl_configuration_test.exs
@@ -28,10 +28,10 @@ defmodule APNS.SslConfigurationTest do
     certs = Path.expand("../../../priv/certs", __DIR__)
     opts = [
       cert: File.read!(Path.join(certs, "dev.crt")),
-      key: File.read!(Path.join(certs, "dev.key"))
+      key:  File.read!(Path.join(certs, "dev.key"))
     ]
     configuration = SslConfiguration.get(opts)
     assert is_binary(Keyword.fetch!(configuration, :cert))
-    assert {:RSAPrivateKey, _key} = Keyword.fetch!(configuration, :key)
+    assert {:PrivateKeyInfo, _key} = Keyword.fetch!(configuration, :key)
   end
 end

--- a/test/lib/apns/state_test.exs
+++ b/test/lib/apns/state_test.exs
@@ -3,8 +3,6 @@ defmodule APNS.StateTest do
 
   alias APNS.State
 
-  @payload_min_size 38
-
   test "get adds merged application defaults with APNS.Configuration defaults and Application level config" do
     configuration = State.get([pool: :test])
 


### PR DESCRIPTION
- Added a backoff timeout, it will use `timeout` from config instead just 1 seconds
- Minor clean up and test fixes
- Better logging when connection fails
- Elixir 1.4 compatibility (removed warnings)
- Library/dependency updates