### PR TITLE
support both private key formats

### DIFF
--- a/lib/apns/ssl_configuration.ex
+++ b/lib/apns/ssl_configuration.ex
@@ -46,8 +46,11 @@ defmodule APNS.SslConfiguration do
 
   defp key(%{key: nil} = config), do: config
   defp key(%{key: binary_key} = config) do
-    [{:PrivateKeyInfo, key_der, _}] = :public_key.pem_decode(binary_key)
-    Map.put(config, :key, {:PrivateKeyInfo, key_der})
+    case :public_key.pem_decode(binary_key) do
+      [{:PrivateKeyInfo, key_der, _}] -> Map.put(config, :key, {:PrivateKeyInfo, key_der})
+      [{:RSAPrivateKey, key_der, _}] -> Map.put(config, :key, {:RSAPrivateKey, key_der})
+      decoded -> raise("can not decode key: #{inspect decoded}")
+    end
   end
 
   defp keyfile(%{keyfile: nil} = config), do: config


### PR DESCRIPTION
For some reason `RSAPrivateKey` keys no longer supported in the new yet to be released 0.9.6 version.
change: https://github.com/chvanikoff/apns4ex/commit/66eb7f66a0bd8094af7bcde5d76f97a1c7a4f846#diff-442a9003adcfbb685c046cf0e7a8a584L49

This pull request restores old functionality, allowing both versions to be used
